### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,6 @@ markdown_extensions:
   - pymdownx.details
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION
- Remove polyfill.io due to a known supply-chain compromise to inject malicious JS code in the mkdocs documentation